### PR TITLE
Changed Shipsprite to only cause wrecks when disasters are enabled

### DIFF
--- a/src/micropolisj/engine/ShipSprite.java
+++ b/src/micropolisj/engine/ShipSprite.java
@@ -118,8 +118,10 @@ public class ShipSprite extends Sprite
 			}
 		}
 		if (!found) {
-			//explodeSprite();
-			//destroyTile(x/16, y/16);
+			if (!city.noDisasters) {
+			explodeSprite();
+			destroyTile(x/16, y/16);
+			}
 		}
 	}
 


### PR DESCRIPTION
The code was already present in the airplanesprite.java file. I'm not sure why it was missing from the shipsprite.java code, but without it there is a spamming of shipwrecks even when disasters are disabled. I added a check for city.nodisasters to run before the explosion code is triggered, thereby avoiding wrecks when disasters are disabled. This allows users to leave the city running in no disaster mode without fear of titanic spam.
