### PR TITLE
Update build.xml

### DIFF
--- a/README
+++ b/README
@@ -24,7 +24,7 @@ Copyright (C) 2002 by Electronic Arts.
 How to Run This Program
 -----------------------
 
-First of all, you must have Java (version 7 or better) installed on your
+First of all, you must have Java (version 9 or better) installed on your
 computer. You can get Java at http://java.com/download.
 
 Next, simply double-click the enclosed micropolisj.jar file to run the

--- a/build.xml
+++ b/build.xml
@@ -78,12 +78,11 @@
 </target>
 
 <target name="compile" depends="init-builddir">
-<javac srcdir="${srcdir}"
-       destdir="${builddir}"
+<javac srcdir="${srcdir}" destdir="${builddir}"
        classpathref="build-classpath"
 	includeantruntime="false"
 	debug="true" debuglevel="lines,vars,source"
-	release="8" source="8" target="8"
+	release="9"
        >
 	<compilerarg value="-Xlint:unchecked" />
 	<compilerarg value="-Xlint:deprecation" />
@@ -127,7 +126,7 @@
 <mkdir dir="docs/api" />
 <javadoc sourcepath="src" destdir="docs/api"
 	classpathref="build-classpath"
-	Private="true"
+	private="true"
 	>
 	<link href="http://docs.oracle.com/javase/7/docs/api" />
 	<link href="http://docs.oracle.com/cd/E17802_01/j2se/javase/technologies/desktop/java3d/forDevelopers/J3D_1_3_API/j3dapi" />

--- a/build.xml
+++ b/build.xml
@@ -83,7 +83,7 @@
        classpathref="build-classpath"
 	includeantruntime="false"
 	debug="true" debuglevel="lines,vars,source"
-	source="1.6" target="1.6"
+	release="8" source="8" target="8"
        >
 	<compilerarg value="-Xlint:unchecked" />
 	<compilerarg value="-Xlint:deprecation" />


### PR DESCRIPTION
Fix for Build Issues updating the build.xml file

Modern versions of Java changed the way this is handled, and also changed the "minimal" version acceptable, this is a temporary fix to allow micropolis-java to build agains modern java versions. Is still a "Deprecated" way to fix it but at least now it builds but at least now build.
